### PR TITLE
fix: replaced packed uint64_t value representation with a tagged union

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 
 set(CMAKE_C_STANDARD 11)
 
-set(CMAKE_CXX_FLAGS "-Wall -Wextra -ffunction-sections -funwind-tables -fstack-protector-strong -fPIC -Wall -Wformat -Werror=format-security -no-canonical-prefixes -std=c99") # -pg
+set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wformat -Wpedantic -Werror -Werror=format-security -ffunction-sections -funwind-tables -fstack-protector-strong -fPIC -no-canonical-prefixes")
 set(CMAKE_CXX_FLAGS_DEBUG "-g")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -ffast-math -march=native -funroll-loops -ftree-vectorize")
 

--- a/adder/compiler/CMakeLists.txt
+++ b/adder/compiler/CMakeLists.txt
@@ -15,5 +15,5 @@ target_sources(adrcom PRIVATE
 )
 
 target_link_libraries(adrcom PUBLIC m adrsha)
-target_compile_options(adrcom PRIVATE -Wall -Wextra -Wpedantic)
+target_compile_options(adrcom PRIVATE -Wall -Wpedantic -Wextra -Werror)
 

--- a/adder/compiler/co_compiler.c
+++ b/adder/compiler/co_compiler.c
@@ -786,7 +786,6 @@ void codegen(ast_node_t* node, compiler_state_t* state) {
 }
 
 void recalc_index_to_bytecode_adress(ir_list_t* instrs, uint32_t* idx2addr) {
-    uint32_t max_addr = idx2addr[instrs->count];
     for (uint32_t i = 0; i < instrs->count; i++) {
         switch(instrs->irs[i].opcode) {
             case OP_CALL:
@@ -794,7 +793,8 @@ void recalc_index_to_bytecode_adress(ir_list_t* instrs, uint32_t* idx2addr) {
             case OP_JUMP:
             case OP_JUMP_IF_FALSE: {
                 uint32_t index = instrs->irs[i].args[0];
-                assert(idx2addr[index] <= max_addr);
+                // assert <= max_address
+                assert(idx2addr[index] <= idx2addr[instrs->count]);
                 instrs->irs[i].args[0] = idx2addr[index];
             } break;
             default: break;
@@ -805,6 +805,7 @@ void recalc_index_to_bytecode_adress(ir_list_t* instrs, uint32_t* idx2addr) {
 void create_index_to_addr_map(ir_list_t* instrs, uint32_t* idx2addr, uint32_t size) {
     uint32_t addr = 0;
     const uint32_t argbytes = 4; // 32-bit args
+    (void)(size);
     assert(instrs->count + 1 <= size);
     for (uint32_t i = 0; i < instrs->count; i++) {
         idx2addr[i] = addr;

--- a/adder/compiler/co_utils.c
+++ b/adder/compiler/co_utils.c
@@ -113,9 +113,39 @@ void valbuffer_destroy(valbuffer_t* buffer) {
     buffer->size = 0;
 }
 
+bool val_compare(val_t a, val_t b) {
+    if( a.type != b.type )
+        return false;
+    switch( a.type ) {
+        case VAL_NONE:
+            return true;
+        case VAL_ARRAY:
+            return (a.u.array.address == b.u.array.address)
+                && (a.u.array.length == b.u.array.length);
+        case VAL_BOOL:
+            return a.u.boolean == b.u.boolean;
+        case VAL_CHAR:
+            return a.u.character == b.u.character;
+        case VAL_FRAME:
+            return (a.u.frame.num_args == b.u.frame.num_args)
+                && (a.u.frame.num_locals == b.u.frame.num_locals)
+                && (a.u.frame.return_pc == b.u.frame.return_pc);
+        case VAL_ITER:
+            return (a.u.iter.current == b.u.iter.current)
+                && (a.u.iter.remaining == b.u.iter.remaining);
+        case VAL_IVEC2:
+            return (a.u.ivec.x == b.u.ivec.x)
+                && (a.u.ivec.y == b.u.ivec.y);
+        case VAL_NUMBER:
+            return a.u.number == b.u.number;
+        default:
+            return false;
+    }
+}
+
 bool valbuffer_linear_search(valbuffer_t* buffer, val_t match, uint32_t* index) {
     for(uint32_t i = 0; i < buffer->size; i++) {
-        if( match == buffer->values[i] ) {
+        if( val_compare(match, buffer->values[i]) ) {
             *index = i;
             return true;
         }

--- a/adder/shared/CMakeLists.txt
+++ b/adder/shared/CMakeLists.txt
@@ -15,4 +15,4 @@ target_sources(adrsha PRIVATE
 )
 
 target_link_libraries(adrsha PUBLIC m)
-target_compile_options(adrsha PRIVATE -Wall -Wextra -Wpedantic)
+target_compile_options(adrsha PRIVATE -Wall -Wpedantic -Wextra -Werror)

--- a/adder/shared/sh_log.c
+++ b/adder/shared/sh_log.c
@@ -26,7 +26,7 @@ void sh_log_init(sh_logprintfn_t printfn) {
 
 void print_wrapper(sh_log_tag_t tag, char* fmt, va_list args) {
     const char* pre = sh_log_preabmle(tag);
-    int pre_len = strnlen(pre, 32);
+    int pre_len = strnlen(pre, 19);
     int fmt_len = strnlen(fmt, SH_LOG_MAX_MESSAGE_LENGTH);
     int len = pre_len + fmt_len;
     

--- a/adder/shared/sh_program.c
+++ b/adder/shared/sh_program.c
@@ -11,7 +11,7 @@
 
 void sprint_value(cstr_t str, val_t* memory, val_t val) {
 
-    if( VAL_GET_TYPE(val) == VAL_ARRAY ) {
+    if( val.type == VAL_ARRAY ) {
         array_t array = val_into_array(val);
         val_t* buffer = memory + MEM_ADDR_TO_INDEX(array.address);
         if( buffer == NULL ) {
@@ -19,7 +19,7 @@ void sprint_value(cstr_t str, val_t* memory, val_t val) {
             return;
         }
         int length = array.length;
-        bool is_list = VAL_GET_TYPE(buffer[0]) != VAL_CHAR;
+        bool is_list = buffer[0].type != VAL_CHAR;
         if(is_list) {
             cstr_append_fmt(str, "[ ");
             for(int i = 0; i < length; i++) {
@@ -33,7 +33,7 @@ void sprint_value(cstr_t str, val_t* memory, val_t val) {
             }
         }
     } else {
-        switch (VAL_GET_TYPE(val))
+        switch (val.type)
         {
         case VAL_NUMBER:
             cstr_append_fmt(str, "%f", val_into_number(val));
@@ -254,7 +254,7 @@ int entry_point_find_any(program_t* prog, char* name, ift_t type, entry_point_t*
 
 entry_point_t program_entry_point_invalid() {
     return (entry_point_t) {
-        .argvals = { 0 },
+        .argvals = {{ 0 }},
         .argcount = -1,
         .address = -1,
         .type = ift_unknown()

--- a/adder/shared/sh_types.h
+++ b/adder/shared/sh_types.h
@@ -15,9 +15,18 @@ typedef struct arena_t {
     uint8_t* data;
 } arena_t;
 
-typedef uint8_t type_id_t;
+typedef enum val_type_t {
+    VAL_NONE,
+    VAL_NUMBER,
+    VAL_IVEC2,
+    VAL_BOOL,
+    VAL_CHAR,
+    VAL_ARRAY,
+    VAL_FRAME,
+    VAL_ITER,
+    VAL_TYPE_COUNT
+} val_type_t;
 
-typedef uint64_t val_t;
 typedef uint32_t val_addr_t;
 
 typedef struct ivec2_t {
@@ -41,17 +50,18 @@ typedef struct iter_t {
     int remaining;      // the number of iterations remaining 
 } iter_t;
 
-typedef enum val_type_t {
-    VAL_NONE,
-    VAL_NUMBER,
-    VAL_IVEC2,
-    VAL_BOOL,
-    VAL_CHAR,
-    VAL_ARRAY,
-    VAL_FRAME,
-    VAL_ITER,
-    VAL_TYPE_COUNT
-} val_type_t;
+typedef struct val_t {
+    val_type_t type;
+    union {
+        float       number;
+        bool        boolean;
+        char        character;
+        ivec2_t     ivec;
+        array_t     array;
+        frame_t     frame;
+        iter_t      iter;
+    } u;
+} val_t;
 
 typedef enum vm_op_t {
     OP_HALT = 0x00,

--- a/adder/shared/sh_value.h
+++ b/adder/shared/sh_value.h
@@ -25,106 +25,119 @@
 
 // VALUE
 
-#define VAL_MK_TYPE_ID(T) ( ((val_t)(T) & 0xF) << 60 )
-#define VAL_GET_TYPE(V)     ((val_type_t)(((val_t)(V)) >> 60))
-
 inline static val_t val_none(void) {
-    return VAL_MK_TYPE_ID(VAL_NONE);
+    return (val_t) {
+        .type = VAL_NONE,
+        .u.boolean = false
+    };
 }
 
 inline static val_t val_number(float value) {
-    uint32_t tmp = *((uint32_t*)&value);
-    return (VAL_MK_TYPE_ID(VAL_NUMBER) | tmp);
+    return (val_t) {
+        .type = VAL_NUMBER,
+        .u.number = value
+    };
 }
 
 inline static val_t val_ivec2(ivec2_t value) {
-    return (VAL_MK_TYPE_ID(VAL_IVEC2) | (value.x << 16) | value.y);
+    return (val_t) {
+        .type = VAL_IVEC2,
+        .u.ivec = value
+    };
 }
 
 inline static val_t val_ivec2_from_args(int16_t x, int16_t y) {
-    return (VAL_MK_TYPE_ID(VAL_IVEC2) | (x << 16) | y);
+    return (val_t) {
+        .type = VAL_IVEC2,
+        .u.ivec = (ivec2_t) {
+            .x = x,
+            .y = y
+        }
+    };
 }
 
 inline static val_t val_bool(bool value) {
-    return (VAL_MK_TYPE_ID(VAL_BOOL) | (value ? 0xFF : 0x00));
+    return (val_t) {
+        .type = VAL_BOOL,
+        .u.boolean = value
+    };
 }
 
 inline static val_t val_char(char value) {
-    return VAL_MK_TYPE_ID(VAL_CHAR) | (((val_t)(value)) & 0xFFFF);
+    return (val_t) {
+        .type = VAL_CHAR,
+        .u.character = value
+    };
 }
 
 inline static val_t val_array(array_t value) {
-    return ( VAL_MK_TYPE_ID(VAL_ARRAY)\
-                            | (  (val_t)(((val_t)(value.length) & 0xFFFFFF) << 32) )\
-                            | (  (val_t)( (val_t)(value.address) & 0xFFFFFFFF    ) ) );
+    return (val_t) {
+        .type = VAL_ARRAY,
+        .u.array = value
+    };
 }
 
 inline static val_t val_array_from_args(val_addr_t addr, int length) {
-    return ( VAL_MK_TYPE_ID(VAL_ARRAY)\
-                            | (  (val_t)(((val_t)(length) & 0xFFFFFF) << 32) )\
-                            | (  (val_t)( (val_t)(addr) & 0xFFFFFFFF       ) ) );
+    return (val_t) {
+        .type = VAL_ARRAY,
+        .u.array = (array_t) {
+            .address = addr,
+            .length = length
+        }
+    };
 }
 
 inline static val_t val_frame(frame_t value) {
-    return ( VAL_MK_TYPE_ID(VAL_FRAME)\
-                            | (  (val_t)(((val_t)(value.num_args) & 0xFF) << 40) )\
-                            | (  (val_t)(((val_t)(value.num_locals) & 0xFF) << 32) )\
-                            | (  (val_t)( (val_t)(value.return_pc) & 0xFFFFFFFF   ) ) );
+    return (val_t) {
+        .type = VAL_FRAME,
+        .u.frame = value
+    };
 }
 
 inline static val_t val_frame_from_args(int return_pc, uint8_t num_args, uint8_t num_locals) {
-    return ( VAL_MK_TYPE_ID(VAL_FRAME)\
-                            | (  (val_t)(((val_t)(num_args) & 0xFF) << 40) )\
-                            | (  (val_t)(((val_t)(num_locals) & 0xFF) << 32) )\
-                            | (  (val_t)( (val_t)(return_pc) & 0xFFFFFFFF   ) ) );
+    return (val_t) {
+        .type = VAL_FRAME,
+        .u.frame = (frame_t) {
+            .num_args = num_args,
+            .num_locals = num_locals,
+            .return_pc = return_pc
+        }
+    };
 }
 
 inline static val_t val_iter(iter_t value) {
-    return ( VAL_MK_TYPE_ID(VAL_ITER)\
-                        | (  (val_t)(((val_t)(value.remaining) & 0xFFFFFF) << 32) )\
-                        | (  (val_t)( (val_t)(value.current) & 0xFFFFFFFF    ) ) );
+    return (val_t) {
+        .type = VAL_ITER,
+        .u.iter = value
+    };
 }
 
 inline static float val_into_number(val_t value) {
-    uint32_t tmp = (uint32_t)(value & 0xFFFFFFFF);
-    return *(float*)&tmp;
+    return value.u.number;
 }
 
 inline static ivec2_t val_into_ivec2(val_t value) {
-    return (ivec2_t) {
-        .x = ((value >> 16) & 0xFFFF),
-        .y = ( value & 0xFFFF )
-    };
+    return value.u.ivec;
 }
 
 inline static bool val_into_bool(val_t value) {
-    return ((((val_t)(value)) & 0xFF) > 0x80);
+    return value.u.boolean;
 }
 
 inline static char val_into_char(val_t value) {
-    return ((char)(((val_t)(value)) & 0xFFFF));
+    return value.u.character;
 }
 
 inline static array_t val_into_array(val_t value) {
-    return (array_t) {
-        .length = (int) (((val_t)(value) >> 32) & 0xFFFFFF),
-        .address = (val_addr_t)((val_t)(value) & 0xFFFFFFFF)
-    };
+    return value.u.array;
 }
 
 inline static frame_t val_into_frame(val_t value) {
-    return (frame_t) {
-        .num_args = (uint8_t) (((val_t)(value) >> 40) & 0xFF),
-        .num_locals = (uint8_t) (((val_t)(value) >> 32) & 0xFF),
-        .return_pc = (int)((val_t)(value) & 0xFFFFFFFF)
-    };
+    return value.u.frame;
 }
 
 inline static iter_t val_into_iter(val_t value) {
-    return (iter_t) {
-        .remaining = (int) (((val_t)(value) >> 32) & 0xFFFFFF),
-        .current = (val_addr_t)((val_t)(value) & 0xFFFFFFFF)
-    };
+    return value.u.iter;
 }
 
 #endif // VM_VALUE_H_

--- a/adder/vm/CMakeLists.txt
+++ b/adder/vm/CMakeLists.txt
@@ -13,4 +13,4 @@ target_sources(adrvm PRIVATE
 )
 
 target_link_libraries(adrvm PUBLIC m adrsha)
-target_compile_options(adrvm PRIVATE -Wall -Wextra -Wpedantic)
+target_compile_options(adrvm PRIVATE -Wall -Wpedantic -Wextra -Werror)

--- a/adder/vm/vm.c
+++ b/adder/vm/vm.c
@@ -386,7 +386,7 @@ val_t vm_execute(vm_t* vm, vm_env_t* env, entry_point_t* ep, program_t* program)
                 // init locals (not needed)
                 uint32_t locals_idx = frame_start + 1 + nargs;
                 for(uint32_t i = 0; i < nlocals; i++) {
-                    stack[locals_idx + i] = 0;
+                    stack[locals_idx + i] = (val_t) { 0 };
                 }
 
                 // make room for the locals on the stack
@@ -423,7 +423,7 @@ val_t vm_execute(vm_t* vm, vm_env_t* env, entry_point_t* ep, program_t* program)
                 // to be too slow.
                 vm_mem->stack.frame = -1;
                 for(int i = vm_mem->stack.top; i >= 0; i--) {
-                    if( VAL_GET_TYPE(stack[i]) == VAL_FRAME ) {
+                    if( stack[i].type == VAL_FRAME ) {
                         vm_mem->stack.frame = i;
                         break;
                     }
@@ -473,7 +473,7 @@ val_t vm_execute(vm_t* vm, vm_env_t* env, entry_point_t* ep, program_t* program)
                 // to be too slow.
                 vm_mem->stack.frame = -1;
                 for(int i = vm_mem->stack.top; i >= 0; i--) {
-                    if( VAL_GET_TYPE(stack[i]) == VAL_FRAME ) {
+                    if( stack[i].type == VAL_FRAME ) {
                         vm_mem->stack.frame = i;
                         break;
                     }

--- a/adder/vm/vm_heap.c
+++ b/adder/vm/vm_heap.c
@@ -29,7 +29,7 @@ void heap_gc_mark_used(vm_t* vm, val_t* checkmem, int val_count) {
     // mark all references
     for(int i = 0; i < val_count; i++) {
         val_t value = checkmem[i];
-        if( VAL_GET_TYPE(value) != VAL_ARRAY ) {
+        if( value.type != VAL_ARRAY ) {
             continue;
         }
         array_t array = val_into_array(value);
@@ -205,7 +205,7 @@ array_t heap_array_alloc(vm_t* vm, int val_count) {
 
     // set all values
     for(int i = 0; i < val_count; i++) {
-        vm->mem.heap.values[addr + i] = 0;
+        vm->mem.heap.values[addr + i] = (val_t){ 0 };
     }
 
     return (array_t) {

--- a/adder/vm/vm_validate.h
+++ b/adder/vm/vm_validate.h
@@ -62,7 +62,7 @@ inline static bool validation_check_stack_args(vm_t* vm, char* context, int arg_
     int stack_top = vm->mem.stack.top;
     for(int i = 0; i < arg_count; i++) {
         val_t arg = vm->mem.stack.values[stack_top - i];
-        val_type_t arg_type = VAL_GET_TYPE(arg);
+        val_type_t arg_type = arg.type;
         val_type_t expected = va_arg(arg_ptr, val_type_t);
         if( expected != arg_type ) {
             snprintf(validation->message, 256,

--- a/adder/vm/vm_value_tools.c
+++ b/adder/vm/vm_value_tools.c
@@ -6,7 +6,7 @@
 
 
 void val_sprint(cstr_t str, val_t val) {
-    switch (VAL_GET_TYPE(val))
+    switch (val.type)
     {
     case VAL_NUMBER:
         cstr_append_fmt(str, "%f", val_into_number(val));
@@ -54,7 +54,7 @@ void val_sprint_string(cstr_t str, val_t* valbuf, int valbuf_length) {
 }
 
 void val_sprint_lookup(cstr_t str, val_t val, addr_lookup_fn lookup, void* user) {
-    if( VAL_GET_TYPE(val) == VAL_ARRAY && lookup != NULL && user != NULL ) {
+    if( val.type == VAL_ARRAY && lookup != NULL && user != NULL ) {
         array_t array = val_into_array(val);
         val_t* buffer = lookup(user, array.address);
         if( buffer == NULL ) {
@@ -62,7 +62,7 @@ void val_sprint_lookup(cstr_t str, val_t val, addr_lookup_fn lookup, void* user)
             return;
         }
         int length = array.length;
-        bool is_list = VAL_GET_TYPE(buffer[0]) != VAL_CHAR;
+        bool is_list = buffer[0].type != VAL_CHAR;
         if(is_list) {
             cstr_append_fmt(str, "[ ");
             for(int i = 0; i < length; i++) {
@@ -81,7 +81,7 @@ void val_sprint_lookup(cstr_t str, val_t val, addr_lookup_fn lookup, void* user)
 }
 
 int val_get_string(val_t val, addr_lookup_fn lookup, void* user, char* dest, int dest_len) {
-    if( lookup == NULL || VAL_GET_TYPE(val) != VAL_ARRAY ) {
+    if( lookup == NULL || val.type != VAL_ARRAY ) {
         return 0;
     }
     array_t array = val_into_array(val);

--- a/adder/xutils/CMakeLists.txt
+++ b/adder/xutils/CMakeLists.txt
@@ -10,4 +10,4 @@ target_sources(xutils PRIVATE
 )
 
 target_link_libraries(xutils PRIVATE adrsha adrcom adrvm)
-target_compile_options(xutils PRIVATE -Wall -Wextra -Wpedantic)
+target_compile_options(xutils PRIVATE -Wall -Wpedantic -Wextra -Werror)

--- a/adder/xutils/xu_lib.c
+++ b/adder/xutils/xu_lib.c
@@ -54,6 +54,7 @@ val_t xu_ffi_to_string(ffi_hndl_meta_t md, int argcount, val_t* args) {
 val_t xu_ffi_add_strings(ffi_hndl_meta_t md, int argcount, val_t* args) {
 
     assert(argcount == 2);
+    (void)(argcount);
 
     array_t a = val_into_array(args[0]);
     array_t b = val_into_array(args[1]);
@@ -221,7 +222,10 @@ val_t xu_alloc_user_string(vm_t* vm, int len, char* str) {
     array_t array = heap_array_alloc(vm, arraylen);
     val_t* ptr = array_get_ptr(vm, array, 0);
     for(int i = 0; i < arraylen; i++) {
-        ptr[i] = str[i + start];
+        ptr[i] = (val_t) {
+            .type = VAL_CHAR,
+            .u.character = str[i + start]
+        };
     }
 
     return val_array(array);
@@ -512,7 +516,7 @@ xu_caller_t mk_invalid_caller(void) {
     return (xu_caller_t) {
         .class = mk_invalid_class(),
         .entrypoint = (entry_point_t) {
-            .argvals = { 0 },
+            .argvals = {{ 0 }},
             .argcount = -1,
             .address = -1
         }

--- a/adrrun/CMakeLists.txt
+++ b/adrrun/CMakeLists.txt
@@ -10,7 +10,7 @@ add_executable(adrrun
     ${CMAKE_CURRENT_SOURCE_DIR}/test/test_runner.c)
 
 target_link_libraries(adrrun PUBLIC m adrcom adrvm adrsha xutils)
-target_compile_options(adrrun PRIVATE -Wall -Wpedantic -Wextra) #  -Werror
+target_compile_options(adrrun PRIVATE -Wall -Wpedantic -Wextra -Werror)
 add_dependencies(adrrun gen-test-header)
 
 # -mavx2 -msse2 -mfma

--- a/adrrun/test/test_runner.c
+++ b/adrrun/test/test_runner.c
@@ -345,7 +345,7 @@ void test_vm(test_case_t* this) {
     val_t ret = vm_execute(&vm, &env, &ep, &program);
 
     TEST_ASSERT_MSG(this,
-        VAL_GET_TYPE(ret) == VAL_NUMBER,
+        ret.type == VAL_NUMBER,
         "#3.1 unexpected return type.");
 
     TEST_ASSERT_MSG(this,
@@ -392,7 +392,7 @@ void test_vm(test_case_t* this) {
     ret = vm_execute(&vm, &env, &ep, &program);
 
     TEST_ASSERT_MSG(this,
-        VAL_GET_TYPE(ret) == VAL_NUMBER,
+        ret.type == VAL_NUMBER,
         "#4.1 unexpected return type.");
 
     TEST_ASSERT_MSG(this,
@@ -506,7 +506,7 @@ void test_ast(test_case_t* this) {
     val_t ret = vm_execute(&vm, &env, &ep, &program);
 
     TEST_ASSERT_MSG(this,
-        VAL_GET_TYPE(ret) == VAL_NUMBER,
+        ret.type == VAL_NUMBER,
         "#1.1 unexpected return type.");
 
     TEST_ASSERT_MSG(this,
@@ -846,7 +846,7 @@ bool test_compile_and_run(test_case_t* this, char* test_category, char* source_c
 
     // TODO: FIX VALUE PRINTING AT SOME POINT!
 
-    switch(VAL_GET_TYPE(res)) {
+    switch(res.type) {
         case VAL_ARRAY: {
             int wlen = vm_get_string(&vm, res, result_as_text, sizeof(result_as_text));
             result_as_text[wlen] = '\0';
@@ -1310,6 +1310,7 @@ void test_xu_classes(test_case_t* this) {
 
 val_t test_alloc(ffi_hndl_meta_t md, int argcount, val_t* args) {
     assert(argcount == 1);
+    (void)(argcount);
     int n = val_into_number(args[0]);
     array_t a = heap_array_alloc(md.vm, n);
     val_t* ptr = array_get_ptr(md.vm, a, 0);


### PR DESCRIPTION
fix: replaced packed uint64_t value representation with a tagged union to get rid of unsafe type punning hack.
note: val_t is now larger than uint64_t (should be adressed when writing the new new VM).